### PR TITLE
fix: resolve LangGraph Studio route conflicts and configure custom app

### DIFF
--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from app.routes.runs import runs_router, threads_router
+from app.routes.runs import runs_router
 
 app = FastAPI()
 
@@ -8,4 +8,4 @@ def health():
     return {"status": "ok"}
 
 app.include_router(runs_router)
-app.include_router(threads_router)
+# Removed threads_router - LangGraph API handles thread management via its built-in routes

--- a/apps/backend/app/routes/runs.py
+++ b/apps/backend/app/routes/runs.py
@@ -4,7 +4,8 @@ from app.schemas.runs import RunStart, RunStatus, RunTrace
 from app.services import runs as run_service
 
 runs_router = APIRouter(prefix="/runs", tags=["runs"])
-threads_router = APIRouter(prefix="/threads", tags=["threads"])
+# Removed threads_router - LangGraph API handles thread management
+# Custom thread routes were conflicting with LangGraph API's built-in routes
 
 
 @runs_router.post("", status_code=status.HTTP_201_CREATED, response_model=RunStatus)
@@ -26,24 +27,3 @@ def get_run_trace(run_id: str):
     if not trace:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="trace not found")
     return trace
-
-
-@threads_router.post("", status_code=status.HTTP_201_CREATED)
-def create_thread():
-    return run_service.create_thread()
-
-
-@threads_router.get("/{thread_id}/state")
-def get_thread_state(thread_id: str):
-    state = run_service.fetch_thread_state(thread_id)
-    if not state:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="thread not found")
-    return state
-
-
-@threads_router.get("/{thread_id}/history")
-def get_thread_history(thread_id: str):
-    history = run_service.fetch_thread_history(thread_id)
-    if history is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="thread history not found")
-    return history

--- a/apps/backend/langgraph.json
+++ b/apps/backend/langgraph.json
@@ -14,5 +14,8 @@
   "graphs": {
     "system_design_agent": "app.agent.system_design.graph:graph"
   },
-  "env": "./.env"
+  "env": "./.env",
+  "http": {
+    "app": "app.main:app"
+  }
 }

--- a/apps/backend/start.sh
+++ b/apps/backend/start.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Startup script for LangGraph API on Render
+# This script ensures LangGraph Studio uses the correct public URL
+
+# Render doesn't automatically provide the public URL, so we need to set it
+# The service URL is: https://system-design-1m99.onrender.com
+# Set this as an environment variable that can be used if needed
+export PUBLIC_URL="${PUBLIC_URL:-https://system-design-1m99.onrender.com}"
+
+# Start LangGraph dev server
+# Note: LangGraph dev mode constructs baseUrl from host:port, which may not work in production
+# For production, consider using LangGraph's production mode or setting up proper URL handling
+exec langgraph dev \
+    --host 0.0.0.0 \
+    --port ${PORT:-10000} \
+    --no-reload \
+    --no-browser \
+    --config langgraph.json
+


### PR DESCRIPTION
- Remove conflicting custom thread routes (/threads/{thread_id}/state and /threads/{thread_id}/history)
- Let LangGraph API handle thread management via built-in routes
- Configure langgraph.json to use custom FastAPI app (app.main:app)
- Add startup script for Render deployment

This fixes the 404 errors when LangGraph Studio tries to fetch thread state. The custom routes were intercepting requests before LangGraph API's built-in routes could handle them.