### PR TITLE
Feat/three panel chat

### DIFF
--- a/apps/web/src/app/actions.ts
+++ b/apps/web/src/app/actions.ts
@@ -114,6 +114,28 @@ export async function fetchStatus(runId: string) {
   return res.json();
 }
 
+// Start a run without waiting for completion (for streaming)
+export async function startRun(input: string): Promise<{ runId: string }> {
+  const tid = await createThread();
+  const payload = {
+    input: {
+      messages: [{ role: "user", content: input }],
+    },
+  };
+  const res = await authFetch(`${BASE}/threads/${tid}/runs/${ASSISTANT_ID}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Failed to start run: ${res.status} ${text}`);
+  }
+  const json = await res.json();
+  const runId: string = json?.id || json?.run_id || null;
+  return { runId };
+}
+
 // Start a run and wait for completion (simple, reliable path)
 export async function startRunWait(input: string): Promise<{ runId: string; state: any | null }> {
   const tid = await createThread();

--- a/apps/web/src/app/actions.ts
+++ b/apps/web/src/app/actions.ts
@@ -137,7 +137,7 @@ export async function startRun(input: string): Promise<{ runId: string }> {
 }
 
 // Start a run and wait for completion (simple, reliable path)
-export async function startRunWait(input: string): Promise<{ runId: string; state: any | null }> {
+export async function startRunWait(input: string): Promise<{ runId: string; state: unknown | null }> {
   const tid = await createThread();
   const payload = {
     input: {

--- a/apps/web/src/app/api/langgraph/threads/[threadId]/stream/route.ts
+++ b/apps/web/src/app/api/langgraph/threads/[threadId]/stream/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest } from "next/server";
+import { createServerSupabase } from "@/utils/supabase/server";
+import { BASE } from "@/utils/langgraph";
+
+export const runtime = "nodejs"; // ensure Node runtime for streaming proxy
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { threadId: string } }
+) {
+  const supabase = await createServerSupabase();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  const token = session?.access_token;
+  if (!token) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const search = req.nextUrl.search || ""; // forward mode params
+  const upstreamUrl = `${BASE}/threads/${params.threadId}/stream${search}`;
+
+  const upstream = await fetch(upstreamUrl, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "text/event-stream",
+    },
+    signal: req.signal,
+  });
+
+  if (!upstream.ok || !upstream.body) {
+    const text = await upstream.text().catch(() => "");
+    return new Response(`Upstream error ${upstream.status}: ${text}`, {
+      status: upstream.status,
+    });
+  }
+
+  // Proxy the stream to the client
+  const responseHeaders = new Headers({
+    "Content-Type": upstream.headers.get("content-type") || "text/event-stream",
+    "Cache-Control": "no-store",
+    Connection: "keep-alive",
+    "Transfer-Encoding": "chunked",
+  });
+
+  return new Response(upstream.body, { headers: responseHeaders });
+}
+
+

--- a/apps/web/src/app/api/langgraph/threads/[threadId]/stream/route.ts
+++ b/apps/web/src/app/api/langgraph/threads/[threadId]/stream/route.ts
@@ -1,11 +1,10 @@
-import { NextRequest } from "next/server";
 import { createServerSupabase } from "@/utils/supabase/server";
 import { BASE } from "@/utils/langgraph";
 
 export const runtime = "nodejs"; // ensure Node runtime for streaming proxy
 
 export async function GET(
-  req: NextRequest,
+  req: Request,
   { params }: { params: { threadId: string } }
 ) {
   const supabase = await createServerSupabase();
@@ -17,7 +16,8 @@ export async function GET(
     return new Response("Unauthorized", { status: 401 });
   }
 
-  const search = req.nextUrl.search || ""; // forward mode params
+  const url = new URL(req.url);
+  const search = url.search || ""; // forward mode params
   const upstreamUrl = `${BASE}/threads/${params.threadId}/stream${search}`;
 
   const upstream = await fetch(upstreamUrl, {
@@ -26,7 +26,7 @@ export async function GET(
       Authorization: `Bearer ${token}`,
       Accept: "text/event-stream",
     },
-    signal: req.signal,
+    signal: (req as any).signal,
   });
 
   if (!upstream.ok || !upstream.body) {

--- a/apps/web/src/app/api/langgraph/threads/[threadId]/stream/route.ts
+++ b/apps/web/src/app/api/langgraph/threads/[threadId]/stream/route.ts
@@ -5,7 +5,7 @@ export const runtime = "nodejs"; // ensure Node runtime for streaming proxy
 
 export async function GET(
   req: Request,
-  ctx: { params: { threadId: string } }
+  ctx: { params: Record<string, string | string[]> }
 ) {
   const supabase = await createServerSupabase();
   const {
@@ -17,9 +17,14 @@ export async function GET(
   }
 
   const { params } = ctx;
+  const threadParam = params.threadId;
+  const threadId = Array.isArray(threadParam) ? threadParam[0] : threadParam;
+  if (!threadId) {
+    return new Response("Thread ID missing", { status: 400 });
+  }
   const url = new URL(req.url);
   const search = url.search || ""; // forward mode params
-  const upstreamUrl = `${BASE}/threads/${params.threadId}/stream${search}`;
+  const upstreamUrl = `${BASE}/threads/${threadId}/stream${search}`;
 
   const upstream = await fetch(upstreamUrl, {
     method: "GET",

--- a/apps/web/src/app/api/langgraph/threads/[threadId]/stream/route.ts
+++ b/apps/web/src/app/api/langgraph/threads/[threadId]/stream/route.ts
@@ -5,7 +5,7 @@ export const runtime = "nodejs"; // ensure Node runtime for streaming proxy
 
 export async function GET(
   req: Request,
-  { params }: { params: { threadId: string } }
+  ctx: { params: { threadId: string } }
 ) {
   const supabase = await createServerSupabase();
   const {
@@ -16,6 +16,7 @@ export async function GET(
     return new Response("Unauthorized", { status: 401 });
   }
 
+  const { params } = ctx;
   const url = new URL(req.url);
   const search = url.search || ""; // forward mode params
   const upstreamUrl = `${BASE}/threads/${params.threadId}/stream${search}`;

--- a/apps/web/src/app/api/langgraph/threads/[threadId]/stream/route.ts
+++ b/apps/web/src/app/api/langgraph/threads/[threadId]/stream/route.ts
@@ -26,7 +26,7 @@ export async function GET(
       Authorization: `Bearer ${token}`,
       Accept: "text/event-stream",
     },
-    signal: (req as any).signal,
+    signal: req.signal,
   });
 
   if (!upstream.ok || !upstream.body) {

--- a/apps/web/src/app/api/langgraph/threads/[threadId]/stream/route.ts
+++ b/apps/web/src/app/api/langgraph/threads/[threadId]/stream/route.ts
@@ -41,8 +41,6 @@ export async function GET(
   const responseHeaders = new Headers({
     "Content-Type": upstream.headers.get("content-type") || "text/event-stream",
     "Cache-Control": "no-store",
-    Connection: "keep-alive",
-    "Transfer-Encoding": "chunked",
   });
 
   return new Response(upstream.body, { headers: responseHeaders });

--- a/apps/web/src/app/api/langgraph/threads/[threadId]/stream/route.ts
+++ b/apps/web/src/app/api/langgraph/threads/[threadId]/stream/route.ts
@@ -5,7 +5,7 @@ export const runtime = "nodejs"; // ensure Node runtime for streaming proxy
 
 export async function GET(
   req: Request,
-  ctx: { params: Record<string, string | string[]> }
+  context: unknown
 ) {
   const supabase = await createServerSupabase();
   const {
@@ -16,8 +16,14 @@ export async function GET(
     return new Response("Unauthorized", { status: 401 });
   }
 
-  const { params } = ctx;
-  const threadParam = params.threadId;
+  const params =
+    typeof context === "object" && context !== null && "params" in context
+      ? (context as { params?: unknown }).params
+      : undefined;
+  const threadParam =
+    typeof params === "object" && params !== null && "threadId" in params
+      ? (params as { threadId?: unknown }).threadId
+      : undefined;
   const threadId = Array.isArray(threadParam) ? threadParam[0] : threadParam;
   if (!threadId) {
     return new Response("Thread ID missing", { status: 400 });

--- a/apps/web/src/app/chat/ChatClient.tsx
+++ b/apps/web/src/app/chat/ChatClient.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useTransition } from "react"
-import { fetchTrace, startRunWait } from "../actions"
+import { fetchTrace, startRunWait, startRun } from "../actions"
 import ArchitecturePanel, { type DesignJson } from "./ArchitecturePanel"
 import TracePanel from "./TracePanel"
 
@@ -27,12 +27,14 @@ type ChatClientProps = {
   runId: string | null
   userId?: string | null
   designJson?: DesignJson | null
+  threadId: string
 }
 
 export default function ChatClient({
   initialMessages,
   runId,
   designJson,
+  threadId,
 }: ChatClientProps) {
   const [messages, setMessages] = useState<ChatMessage[]>(initialMessages)
   const [input, setInput] = useState("")
@@ -41,6 +43,71 @@ export default function ChatClient({
   const [isPending, startTransition] = useTransition()
   const [currentRunId, setCurrentRunId] = useState<string | null>(runId)
   const [architecture, setArchitecture] = useState<DesignJson | null>(designJson ?? null)
+  const [streaming, setStreaming] = useState<boolean>(false)
+  const [streamError, setStreamError] = useState<string | null>(null)
+
+  // Open a single stream per thread; reuse across runs
+  async function ensureStream() {
+    if (streaming) return
+    setStreaming(true)
+    setStreamError(null)
+    try {
+      const res = await fetch(`/api/langgraph/threads/${threadId}/stream?mode=values,updates`)
+      if (!res.ok || !res.body) {
+        setStreamError(`Stream error: ${res.status}`)
+        setStreaming(false)
+        return
+      }
+      const reader = res.body.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ""
+      ;(async () => {
+        try {
+          while (true) {
+            const { done, value } = await reader.read()
+            if (done) break
+            buffer += decoder.decode(value, { stream: true })
+            // Try parsing SSE "data: ...\n\n" blocks first
+            let idx
+            while ((idx = buffer.indexOf("\n\n")) !== -1) {
+              const block = buffer.slice(0, idx)
+              buffer = buffer.slice(idx + 2)
+              const line = block.split("\n").find(l => l.startsWith("data:")) || block
+              const payload = line.replace(/^data:\s*/, "").trim()
+              if (!payload) continue
+              try {
+                const evt = JSON.parse(payload)
+                handleStreamEvent(evt)
+              } catch (e) {
+                // try NDJSON fallback
+                try { handleStreamEvent(JSON.parse(block.trim())) } catch {}
+              }
+            }
+          }
+        } catch (e) {
+          setStreamError(e instanceof Error ? e.message : "stream read error")
+        } finally {
+          setStreaming(false)
+        }
+      })()
+    } catch (e) {
+      setStreamError(e instanceof Error ? e.message : "stream error")
+      setStreaming(false)
+    }
+  }
+
+  function handleStreamEvent(evt: any) {
+    // Update architecture when values arrive
+    const values = evt?.values || evt?.state?.values || null
+    if (values) {
+      const arch = values.architecture_json || values.design_json || null
+      if (arch) setArchitecture(arch)
+      const output = typeof values.output === "string" ? values.output : null
+      if (output && output.trim()) {
+        setMessages(prev => [...prev, { role: "assistant", content: output }])
+      }
+    }
+  }
 
   const loadTrace = () => {
     if (!currentRunId) {
@@ -83,24 +150,33 @@ export default function ChatClient({
     setInput("")
 
     try {
-      const { runId: newRunId, state } = await startRunWait(trimmed)
+      // Ensure stream is open for live updates
+      ensureStream()
+
+      // Prefer non-blocking start; if it fails, fallback to wait
+      let newRunId: string | null = null
+      try {
+        const r = await startRun(trimmed)
+        newRunId = r.runId
+      } catch (e) {
+        const r = await startRunWait(trimmed)
+        newRunId = r.runId
+        const values = (r.state && (r.state as any).values) || null
+        const arch = values?.architecture_json || values?.design_json || null
+        if (arch) setArchitecture(arch)
+        const output = typeof values?.output === "string" ? values.output : null
+        if (output && output.trim().length > 0) {
+          setMessages((prev) => [...prev, { role: "assistant", content: output }])
+        } else if (newRunId) {
+          setMessages((prev) => [...prev, { role: "assistant", content: `Run completed (${newRunId})` }])
+        }
+      }
       if (newRunId) {
         setCurrentRunId(newRunId)
         setTrace(null)
-      }
-      const values = (state && (state as any).values) || null
-      const arch = values?.architecture_json || values?.design_json || null
-      if (arch) setArchitecture(arch)
-      const output = typeof values?.output === "string" ? values.output : null
-      if (output && output.trim().length > 0) {
-        setMessages((prev) => [...prev, { role: "assistant", content: output }])
-      } else if (newRunId) {
-        setMessages((prev) => [...prev, { role: "assistant", content: `Run completed (${newRunId})` }])
-      }
-      if (newRunId) {
         startTransition(async () => {
           try {
-            const data = await fetchTrace(newRunId)
+            const data = await fetchTrace(newRunId!)
             setTrace(data)
             setTraceError(null)
           } catch (err) {

--- a/apps/web/src/app/chat/page.tsx
+++ b/apps/web/src/app/chat/page.tsx
@@ -4,7 +4,7 @@ import { getState } from "../actions";
 import type { DesignJson } from "./ArchitecturePanel";
 
 export default async function Page() {
-  const { runId, state } = await getState(undefined, { redirectTo: "/chat" });
+  const { threadId, runId, state } = await getState(undefined, { redirectTo: "/chat" });
   const initialMessages: { role: "user" | "assistant" | "system"; content: string }[] = [];
   const userId = state?.values?.user_id ?? null;
   // Prefer architecture_json for the left panel; fall back to design_json if present
@@ -14,7 +14,7 @@ export default async function Page() {
     null;
   return (
     <ChatGuard>
-      <ChatClient userId={userId} initialMessages={initialMessages} runId={runId} designJson={designJson} />
+      <ChatClient userId={userId} initialMessages={initialMessages} runId={runId} designJson={designJson} threadId={threadId} />
     </ChatGuard>
   );
 }

--- a/apps/web/src/app/chat/page.tsx
+++ b/apps/web/src/app/chat/page.tsx
@@ -4,7 +4,7 @@ import { getState } from "../actions";
 import type { DesignJson } from "./ArchitecturePanel";
 
 export default async function Page() {
-  const { threadId, runId, state } = await getState(undefined, { redirectTo: "/chat" });
+  const { runId, state } = await getState(undefined, { redirectTo: "/chat" });
   const initialMessages: { role: "user" | "assistant" | "system"; content: string }[] = [];
   const userId = state?.values?.user_id ?? null;
   // Prefer architecture_json for the left panel; fall back to design_json if present
@@ -14,7 +14,7 @@ export default async function Page() {
     null;
   return (
     <ChatGuard>
-      <ChatClient userId={userId} initialMessages={initialMessages} runId={runId} designJson={designJson} threadId={threadId} />
+      <ChatClient userId={userId} initialMessages={initialMessages} runId={runId} designJson={designJson} />
     </ChatGuard>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce server actions to start runs (with wait), add an authenticated SSE streaming proxy, and refactor ChatClient to use wait flow, update architecture from state, and auto-load trace.
> 
> - **Backend**:
>   - **Server actions** in `apps/web/src/app/actions.ts`:
>     - Add `startRun(input)` and `startRunWait(input)` to create thread runs (including `/wait`).
>   - **Streaming proxy**: new route `apps/web/src/app/api/langgraph/threads/[threadId]/stream/route.ts` that forwards authenticated SSE from `BASE`.
> - **Frontend**:
>   - **ChatClient** (`apps/web/src/app/chat/ChatClient.tsx`):
>     - Replace `/api/messages` call with `startRunWait` and handle completion result.
>     - Extract `architecture_json`/`design_json` and `output` from returned state; update `ArchitecturePanel` and append assistant reply.
>     - Track `currentRunId`; fetch and display trace post-run; improved error handling and trace refresh.
>     - Minor state helpers and wiring for 3-panel layout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2300afa218d0191635b84907200a6a53f0279f57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->