### PR TITLE
Feat/three panel chat

### DIFF
--- a/apps/web/src/app/chat/ChatClient.tsx
+++ b/apps/web/src/app/chat/ChatClient.tsx
@@ -91,7 +91,16 @@ export default function ChatClient({
     setInput("")
 
     try {
-      const { runId: newRunId, state } = await startRunWait(trimmed)
+      const result = await startRunWait(trimmed)
+      if (!result.ok) {
+        const errorMessage = result.error || 'Run failed'
+        setMessages((prev) => [
+          ...prev,
+          { role: 'assistant', content: `Sorry, something went wrong: ${errorMessage}` },
+        ])
+        return
+      }
+      const { runId: newRunId, state } = result
       const values = getValuesFromStateLike(state)
       const arch = (values?.["architecture_json"] || values?.["design_json"]) as unknown
       if (arch && typeof arch === "object") setArchitecture(arch as DesignJson)

--- a/apps/web/src/utils/langgraph.ts
+++ b/apps/web/src/utils/langgraph.ts
@@ -1,5 +1,5 @@
-export const BASE = 
-    process.env.NEXT_PUBLIC_LANGGRAPH_BASE_URL || "http://127.0.0.1:2024"; // local dev defailt 
+export const BASE =
+  process.env.NEXT_PUBLIC_LANGGRAPH_BASE_URL || "https://system-design-1m99.onrender.com";
 
 export const ASSISTANT_ID = "system_design_agent"; // to match langgraph.json in the backend
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds architecture normalization and fallback in the backend finaliser, allows empty relations, and updates the web app to return structured run results with user-facing error handling plus a prod BASE URL.
> 
> - **Backend (system_design)**:
>   - Add architecture normalization helpers (`_coerce_str`, `_match_enum`, `_normalise_tags`, `_strip_nulls`, `_fallback_architecture`, `normalise_architecture`).
>   - Finaliser: strip nulls, normalize `architecture`, retry validation, and provide a minimal markdown/architecture fallback on repeated schema failures.
>   - Schema: allow empty `relations` (`minItems` 1 → 0).
> - **Web**:
>   - Actions: introduce `RunResult` (`ok`/`error`) with `buildRunFailure`; update `startRun`/`startRunWait` to return structured results instead of throwing.
>   - ChatClient: handle failed runs by displaying concise assistant error messages; persist new `runId` and auto-fetch trace on success.
>   - Config: change `BASE` default to production URL in `utils/langgraph.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b66e06124957795222f668ce1836fd61954b3d05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->